### PR TITLE
Fix source code lookup and loading

### DIFF
--- a/impacker/core/impacker.py
+++ b/impacker/core/impacker.py
@@ -243,7 +243,7 @@ class Impacker:
         return code
 
     def has_source_code(self, spec: ModuleSpec) -> bool:
-        return spec.origin in self._source_code_cache
+        return Path(spec.origin or "") in self._source_code_cache
 
     def _put_source_code(self, code: SourceCode):
         self._source_code_cache[Path(code.spec.origin or "")] = code

--- a/impacker/core/source_code.py
+++ b/impacker/core/source_code.py
@@ -62,6 +62,8 @@ class SourceCode:
     def from_path(src_path: Path|str):
         if not isinstance(src_path, Path):
             src_path = Path(src_path)
+        if not src_path.is_file():
+            return None
         spec = spec_from_file_location(src_path.stem, src_path)
         return SourceCode(spec) if spec else None
 


### PR DESCRIPTION
## Summary
- check cache against Path objects when looking up SourceCode
- avoid FileNotFoundError in `SourceCode.from_path`

## Testing
- `python -m test`


------
https://chatgpt.com/codex/tasks/task_e_686fcce6875c8327b887c0e4f5bd4918