### PR TITLE
Fix KeyError in Impacker mark requires

### DIFF
--- a/impacker/core/impacker.py
+++ b/impacker/core/impacker.py
@@ -182,7 +182,7 @@ class Impacker:
         self.log(f"- Inspecting {code} for {repr(requires)}...")
 
         code_id = id(code)
-        req_set = self._source_code_requires[code_id]
+        req_set = self._source_code_requires.get(code_id)
         if req_set is None:
             req_set = set[str]()
             self._source_code_requires[code_id] = req_set


### PR DESCRIPTION
## Summary
- fix KeyError when marking required definitions by using `.get`

## Testing
- `python -m test`

------
https://chatgpt.com/codex/tasks/task_e_686fcce6875c8327b887c0e4f5bd4918